### PR TITLE
Correct a spelling mistake in SecurityProperties

### DIFF
--- a/whoiswho-backend/src/main/java/be/g000glen00b/whoiswho/security/SecurityProperties.java
+++ b/whoiswho-backend/src/main/java/be/g000glen00b/whoiswho/security/SecurityProperties.java
@@ -13,7 +13,7 @@ import java.time.Duration;
 @RequiredArgsConstructor
 public class SecurityProperties {
     /**
-     * Amound of hashing iterations, where formula is 2^passwordStrength iterations
+     * Amount of hashing iterations, where formula is 2^passwordStrength iterations
      */
     private final int passwordStrength;
     /**


### PR DESCRIPTION
replace `Amound` to `Amount` in SecurityProperties.java